### PR TITLE
StaticLib.cのToDoを実装して、ユニットテストが通るようにしました。

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ただし、中身が実装されていません。
 実装して、ユニットテストが通るようにしてください。
 
-[![MS Build and Test](https://github.com/tpu-game-2024/comp2_4_array/actions/workflows/ms_test.yml/badge.svg)](https://github.com/tpu-game-2024/comp2_4_array/actions/workflows/ms_test.yml)
+[![MS Build and Test](https://github.com/YamakawaMinori/comp2_4_array/actions/workflows/ms_test.yml/badge.svg)](https://github.com/YamakawaMinori/comp2_4_array/actions/workflows/ms_test.yml)
 
 （このファイルの上の行の「tpu-game-2024」の部分（2か所）を自分のアカウント名に修正してください）
 

--- a/src/StaticLib/StaticLib.c
+++ b/src/StaticLib/StaticLib.c
@@ -35,14 +35,35 @@ void release(my_array* ar)
 void resize(my_array* ar, int n)
 {
 	// ToDo:配列の要素数を変更しよう！(reallocは禁止)
+
+	int* a = (int*)malloc(sizeof(int) * n);
+
+	if (ar == NULL) return;// NULLチェック
+
+	if (ar->addr != NULL) { // 非正の値が来たら、とりあえず空にする
+		//nまでの要素に入っている値を*aにコピーする。
+		memcpy_s(a, sizeof(int) * n, ar->addr, sizeof(int) * min(n, ar->num));
+	}
+
+	ar->num = n;
+	//コピーしたaを代入することで範囲内の値を残す。
+	ar->addr = a;
 }
 
 // my_array のindex番目の要素にvalを設定する
 // index が確保されていない場所を指していたら返り値をfalseにする（設定出来たらtrue）
 bool set(my_array* ar, int index, int val)
 {
+
 	// ToDo:配列の要素を変更しよう！
-	return false;
+
+	if (ar == NULL || ar->addr == NULL
+		|| ar->num <= index || index < 0) return false;
+
+		//ar->addrのindex番目にvalを代入する。
+		ar->addr[index] = val;
+		return true;
+
 }
 
 // my_array のindex番目の要素を取得する
@@ -50,12 +71,18 @@ bool set(my_array* ar, int index, int val)
 int get(const my_array* ar, int index)
 {
 	// ToDo:要素を所得して、indexがおかしかったら0を返そう
-	return -1;
+	
+	if (ar == NULL || ar->addr == NULL
+		|| ar->num <= index || index < 0) return 0;
+
+		return ar->addr[index];
 }
 
 // my_array の要素数を取得する
 int size(const my_array* ar)
 {
 	// ToDo: 配列の要素数を返そう
-	return -1;
+	//値が入っていないなら0を返す。
+	if (ar == NULL || ar->addr == NULL) return 0;
+	return ar->num;
 }

--- a/src/StaticLib/StaticLib.c
+++ b/src/StaticLib/StaticLib.c
@@ -59,7 +59,7 @@ bool set(my_array* ar, int index, int val)
 
 	if (ar == NULL || ar->addr == NULL) return false;
 
-	if (ar->num > index>= 0)
+	if (ar->num > index && index >= 0)
 	{
 		//ar->addrのindex番目にvalを代入する。
 		ar->addr[index] = val;
@@ -77,7 +77,7 @@ int get(const my_array* ar, int index)
 	
 	if (ar == NULL || ar->addr == NULL) return 0;
 
-	if (ar->num > index >= 0)
+	if (ar->num > index && index >= 0)
 	{
 		return ar->addr[index];
 	}

--- a/src/StaticLib/StaticLib.c
+++ b/src/StaticLib/StaticLib.c
@@ -57,13 +57,16 @@ bool set(my_array* ar, int index, int val)
 
 	// ToDo:配列の要素を変更しよう！
 
-	if (ar == NULL || ar->addr == NULL
-		|| ar->num <= index || index < 0) return false;
+	if (ar == NULL || ar->addr == NULL) return false;
 
+	if (ar->num > index>= 0)
+	{
 		//ar->addrのindex番目にvalを代入する。
 		ar->addr[index] = val;
 		return true;
-
+	}
+	
+	return false;
 }
 
 // my_array のindex番目の要素を取得する
@@ -72,10 +75,16 @@ int get(const my_array* ar, int index)
 {
 	// ToDo:要素を所得して、indexがおかしかったら0を返そう
 	
-	if (ar == NULL || ar->addr == NULL
-		|| ar->num <= index || index < 0) return 0;
+	if (ar == NULL || ar->addr == NULL) return 0;
 
+	if (ar->num > index >= 0)
+	{
 		return ar->addr[index];
+	}
+
+	//indexが確保されていない場所を指していたら0を返す。
+
+	return 0;
 }
 
 // my_array の要素数を取得する


### PR DESCRIPTION
質問なのですが、
StaticLib.cのToDoを実装するときに、
このように書き進めたところテストが通らなくて、
プルリクエストする条件分岐の範囲とは判定は変わるところがないと思っているのですが。
どうしてテストが通らなかったのでしょうか。
教えていただけたら幸いです。

bool set(my_array* ar, int index, int val)
{

	// ToDo:配列の要素を変更しよう！

	if (ar == NULL || ar->addr == NULL) return false;

	if (ar->num > index >= 0)
	{
		//ar->addrのindex番目にvalを代入する。
		ar->addr[index] = val;
		return true;
	}
	
	return false;
}

// my_array のindex番目の要素を取得する
// index が確保されていない場所を指していたら0を返す
int get(const my_array* ar, int index)
{
	// ToDo:要素を所得して、indexがおかしかったら0を返そう
	
	if (ar == NULL || ar->addr == NULL) return 0;

	if (ar->num > index >= 0)
	{
		return ar->addr[index];
	}

	//indexが確保されていない場所を指していたら0を返す。

	return 0;
}